### PR TITLE
feat: IAMロール(Datastore)のアタッチ

### DIFF
--- a/infra/techsnap/gc_iam_datastore.tf
+++ b/infra/techsnap/gc_iam_datastore.tf
@@ -1,0 +1,8 @@
+# Datastore 用の IAM ロール付与
+resource "google_project_iam_member" "cloud_run_datastore_roles" {
+  for_each = toset(var.datastore_iam_roles)
+
+  project = local.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}

--- a/infra/techsnap/gc_project_services.tf.disabled
+++ b/infra/techsnap/gc_project_services.tf.disabled
@@ -1,0 +1,25 @@
+# 共通で必要となる Google Cloud API の有効化を行うリソース定義
+locals {
+  # tfvars から渡される environment / project の整合をここで吸収
+  project_id             = var.project_id
+  region                 = coalesce(try(var.project_settings.region, null), var.region)
+  environment_normalized = lower(coalesce(var.env, try(var.project_settings.environment, null), var.environment))
+
+  required_apis = [
+    "artifactregistry.googleapis.com",
+    "run.googleapis.com",
+    "iam.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
+    "secretmanager.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com"
+  ]
+}
+
+resource "google_project_service" "required" {
+  for_each           = toset(local.required_apis)
+  project            = local.project_id
+  service            = each.value
+  disable_on_destroy = false
+}

--- a/infra/techsnap/valiables.tf
+++ b/infra/techsnap/valiables.tf
@@ -79,6 +79,12 @@ variable "iam_settings" {
   })
 }
 
+variable "datastore_iam_roles" {
+  description = "Datastore へアクセスさせるために Cloud Run サービスアカウントへ付与する IAM ロール一覧"
+  type        = list(string)
+  default     = []
+}
+
 # Cloud SQL の設定
 variable "monitoring_settings" {
   description = "Monitoring の設定"


### PR DESCRIPTION
アプリをCloud Datastoreを経由した運用に変更するため、Cloud Run用のIAMユーザーにDatastoreロールをアタッチ