### PR TITLE
feat: フィード プリフェッチ用の Cloud Run ジョブとスケジューラを追加

### DIFF
--- a/apps/jobs/summarizer/Dockerfile
+++ b/apps/jobs/summarizer/Dockerfile
@@ -1,0 +1,24 @@
+# Stage 1: 開発依存込みでインストールしてビルド
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install       # devDependencies 含む
+
+COPY . .
+RUN npm run build     # package.json に "build": "tsc -p tsconfig.json" 等を追加しておく
+
+# Stage 2: 本番用に最小構成を作成
+FROM node:18-alpine
+
+WORKDIR /app
+
+# 本番用に production 依存だけコピー
+COPY package*.json ./
+RUN npm install --production
+
+# ビルド成果物をコピー
+COPY --from=builder /app/dist ./dist
+
+CMD ["node", "dist/index.js"]

--- a/apps/jobs/summarizer/package.json
+++ b/apps/jobs/summarizer/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "Cloud Run job for Techsnap article summarization",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
     "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js"
   },
   "type": "commonjs",

--- a/infra/techsnap/gc_cloud_run_job.tf
+++ b/infra/techsnap/gc_cloud_run_job.tf
@@ -1,0 +1,50 @@
+# Prefetch feeds Cloud Run Job
+resource "google_cloud_run_v2_job" "prefetch_feeds" {
+  name     = "prefetch-feeds"
+  location = var.region
+
+  template {
+    template {
+      containers {
+        image = "${var.prefetch_feeds_image}"
+
+        env {
+          name  = "FEED_CRON_ORIGIN"
+          value = var.feed_cron_origin
+        }
+
+        env {
+          name  = "FORCE_REFRESH"
+          value = var.force_refresh
+        }
+      }
+    }
+  }
+}
+
+# Cloud Scheduler -> Cloud Run Job
+resource "google_cloud_scheduler_job" "prefetch_feeds_schedule" {
+  name        = var.cloud_scheduler_settings.job_name
+  description = var.cloud_scheduler_settings.description
+  schedule    = var.cloud_scheduler_settings.schedule
+  time_zone   = var.cloud_scheduler_settings.time_zone
+  region      = var.region
+  project     = var.project_id
+
+  retry_config {
+    retry_count          = var.cloud_scheduler_settings.retry_count
+    max_retry_duration   = var.cloud_scheduler_settings.max_duration
+    min_backoff_duration = "10s"
+    max_backoff_duration = "60s"
+    max_doublings        = 5
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.prefetch_feeds.name}:run"
+    oidc_token {
+      service_account_email = google_service_account.cloud_run.email
+      audience              = "https://${var.region}-run.googleapis.com/"
+    }
+  }
+}

--- a/infra/techsnap/valiables.tf
+++ b/infra/techsnap/valiables.tf
@@ -22,6 +22,12 @@ variable "project_id" {
   type        = string
 }
 
+variable "env" {
+  description = "環境名 (例: ステージングまたは本番環境)。未指定時は project_settings.environment を使用"
+  type        = string
+  default     = null
+}
+
 # Artifact Registry の設定
 variable "artifact_registry_settings" {
   description = "Artifact Registry の設定"
@@ -32,12 +38,6 @@ variable "artifact_registry_settings" {
     cleanup_keep_version     = optional(number, 2)
     cleanup_delete_tag_state = optional(string, "ANY")
   })
-}
-
-variable "env" {
-  description = "環境名 (例: ステージングまたは本番環境)。未指定時は project_settings.environment を使用"
-  type        = string
-  default     = null
 }
 
 variable "service_account_email" {
@@ -70,6 +70,41 @@ variable "cloud_run_settings" {
   })
 }
 
+# Cloud Run ジョブの設定
+
+variable "prefetch_feeds_image" {
+  description = "Container image for prefetch feeds job"
+  type        = string
+}
+variable "feed_cron_origin" {
+  description = "The origin URL for the feed cron job"
+  type        = string
+}
+
+variable "force_refresh" {
+  description = "Flag to force refresh feeds"
+  type        = string
+}
+
+# Cloud Scheduler の設定
+variable "cloud_scheduler_settings" {
+  description = "Cloud Scheduler の設定"
+  type = object({
+    job_name     = string
+    description  = string
+    schedule     = string
+    time_zone    = string
+    retry_count  = number
+    max_duration = string
+  })
+}
+
+variable "schedule_cron" {
+  description = "Cloud Scheduler ジョブの cron 式"
+  type        = string
+  default     = "0 * * * *"
+}
+
 # IAM の設定
 variable "iam_settings" {
   description = "IAM の設定"
@@ -85,7 +120,7 @@ variable "datastore_iam_roles" {
   default     = []
 }
 
-# Cloud SQL の設定
+# Monitoring の設定
 variable "monitoring_settings" {
   description = "Monitoring の設定"
   type = object({


### PR DESCRIPTION
## 概要
- prefetch-feeds 用の Cloud Run ジョブと Cloud Scheduler ジョブを Terraformで定義
- ジョブが利用する Datastore/要約スキーマ、tfvars、Dockerビルド設定を追加
- 既存 Cloud Run サービス用定義を削除し、CI ワークフローを復元

## 変更点
- `apps/jobs/summarizer` にDockerfile と build スクリプトを追加
- Terraform に Cloud Run Job(`google_cloud_run_v2_job`) と Scheduler ジョブを追加
- `.github/workflows/prefetch-feeds.yml` と `build-and-push.yml` を復元
- `valiables.tf`,`staging.tfvars`, `prod.tfvars` をジョブ用に整理

## テスト
- `terraform plan/apply -var-file=env/staging.tfvars`
- `terraform plan/apply -var-file=env/prod.tfvars`
- Cloud Run Job / Cloud Scheduler の実行を Staging / Prod で確認