### PR TITLE
Fix GitHub summary step for prefetch job

### DIFF
--- a/.github/workflows/prefetch-feeds.yml
+++ b/.github/workflows/prefetch-feeds.yml
@@ -53,5 +53,9 @@ jobs:
 
       - name: Summary
         if: ${{ env.SHOULD_RUN == 'true' }}
+        env:
+          SUMMARY_JOB_NAME: ${{ matrix.job_name }}
+          SUMMARY_ENV_NAME: ${{ matrix.env_name }}
+          SUMMARY_PROJECT_ID: ${{ matrix.project_id }}
         run: |
-          echo "Triggered job ${{ matrix.job_name }} in ${{ matrix.env_name }} (${{ matrix.project_id }})" >> $GITHUB_STEP_SUMMARY
+          echo "Triggered job ${SUMMARY_JOB_NAME} in ${SUMMARY_ENV_NAME} (${SUMMARY_PROJECT_ID})" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
.github/workflows/prefetch-feeds.yml:55-63 で Summary ステップを修正し、matrix の値を事前に環境変数へ展開してから echo で参照するようにした。
これで GitHub のマスキング処理が $***matrix.project_id*** のような不正な代入に化けず、bad substitution が解消されるはず。